### PR TITLE
Update __init__.py

### DIFF
--- a/diffnext/utils/__init__.py
+++ b/diffnext/utils/__init__.py
@@ -17,3 +17,4 @@
 
 from diffnext.utils.export_utils import export_to_image
 from diffnext.utils.export_utils import export_to_video
+from diffnext.utils.registry import Registry


### PR DESCRIPTION
Running the image generation example in the README ran into an import error:


" ... NOVA/diffnext/models/transformers/transformer_nova.py", line 27, in <module>
    from diffnext.utils import Registry
ImportError: cannot import name 'Registry' from 'diffnext.utils'

Adding this line seems like the direct fix.